### PR TITLE
Server dropdown selector implementation

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,4 +6,5 @@ target 'TraccarManager' do
   pod 'Firebase/Messaging'
   pod 'Fabric'
   pod 'Crashlytics'
+  pod 'iOSDropDown'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,6 +72,7 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (6.3.1):
     - GoogleUtilities/Logger
+  - iOSDropDown (0.3.4)
   - nanopb (0.3.901):
     - nanopb/decode (= 0.3.901)
     - nanopb/encode (= 0.3.901)
@@ -84,6 +85,7 @@ DEPENDENCIES:
   - Fabric
   - Firebase/Core
   - Firebase/Messaging
+  - iOSDropDown
 
 SPEC REPOS:
   trunk:
@@ -101,6 +103,7 @@ SPEC REPOS:
     - GoogleDataTransport
     - GoogleDataTransportCCTSupport
     - GoogleUtilities
+    - iOSDropDown
     - nanopb
     - Protobuf
 
@@ -119,9 +122,10 @@ SPEC CHECKSUMS:
   GoogleDataTransport: c8617c00e4f3eb9418e42ac0e8ac5241a9d555dd
   GoogleDataTransportCCTSupport: 9f352523e8785a71f6754f51eeff09f49ec19268
   GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
+  iOSDropDown: c10a761f9a00c3f1cc9d3bce43ae504628e2f692
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
 
-PODFILE CHECKSUM: 3a2ad981f2c01bf0803a65d3962d2f6e283859f6
+PODFILE CHECKSUM: 626c8f845a4509b6de29fa15a8e03cd5ab1a0139
 
-COCOAPODS: 1.8.1
+COCOAPODS: 1.9.1

--- a/TraccarManager.xcodeproj/project.pbxproj
+++ b/TraccarManager.xcodeproj/project.pbxproj
@@ -185,12 +185,14 @@
 				"${PODS_ROOT}/Target Support Files/Pods-TraccarManager/Pods-TraccarManager-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/iOSDropDown/iOSDropDown.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/iOSDropDown.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TraccarManager/AppDelegate.swift
+++ b/TraccarManager/AppDelegate.swift
@@ -25,12 +25,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        if UserDefaults.standard.object(forKey: "url") != nil {
-            self.window = UIWindow(frame: UIScreen.main.bounds)
-            let storyboard = UIStoryboard(name: "Main", bundle: nil)
-            self.window?.rootViewController = storyboard.instantiateViewController(withIdentifier: "MainViewController")
-            self.window?.makeKeyAndVisible()
-        }
+//        if UserDefaults.standard.object(forKey: "url") != nil {
+//            self.window = UIWindow(frame: UIScreen.main.bounds)
+//            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+//            self.window?.rootViewController = storyboard.instantiateViewController(withIdentifier: "MainViewController")
+//            self.window?.makeKeyAndVisible()
+//        }
         
         NotificationCenter.default.addObserver(self, selector: #selector(onReceive(_:)), name: MainViewController.eventLogin, object: nil)
 

--- a/TraccarManager/Base.lproj/Main.storyboard
+++ b/TraccarManager/Base.lproj/Main.storyboard
@@ -78,8 +78,8 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6K-5s-OQ0" userLabel="Info">
-                                <rect key="frame" x="16" y="131.5" width="343" height="81.5"/>
-                                <string key="text">This screen will be shown only once. After you click the button, server address will be saved in preferences. To change it, clear app data from application manager.</string>
+                                <rect key="frame" x="16" y="131.5" width="343" height="162.5"/>
+                                <string key="text">This screen will be shown every time application is launched if it was not running. After you put correct server address and click the button, server address will be saved in preferences and will be shown in dropdown next time among other saved URLs. To remove all saved URLs, clear app data from application manager.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>

--- a/TraccarManager/Base.lproj/Main.storyboard
+++ b/TraccarManager/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Q9M-Zf-myH">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Q9M-Zf-myH">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -48,10 +48,25 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="http://demo.traccar.org" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WfE-A8-W7r" userLabel="ServerField">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" usesAttributedText="YES" borderStyle="roundedRect" placeholder="Select URL" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WfE-A8-W7r" userLabel="ServerField" customClass="DropDown" customModule="iOSDropDown">
                                 <rect key="frame" x="124" y="81.5" width="235" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="http://demo.traccar.org">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <font key="NSFont" metaFont="menu" size="14"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
                                 <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rowHeight">
+                                        <real key="value" value="50"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="listHeight">
+                                        <real key="value" value="250"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9rJ-sw-k3E" userLabel="ServerLabel">
                                 <rect key="frame" x="16" y="88.5" width="100" height="20.5"/>

--- a/TraccarManager/StartViewController.swift
+++ b/TraccarManager/StartViewController.swift
@@ -58,9 +58,9 @@ class StartViewController: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         serverField.delegate = self
-        serverField.optionArray = ["URL_1",
-                                   "URL_2",
-                                   "URL_3"]
+        if let data = UserDefaults.standard.value(forKey:"serverUrlArray") as? Data {
+            serverField.optionArray = try! PropertyListDecoder().decode(Array<String>.self, from: data)
+        }
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -70,7 +70,19 @@ class StartViewController: UIViewController, UITextFieldDelegate {
 
     func onSuccess() {
         UserDefaults.standard.set(serverField.text, forKey: "url")
+        storeProvidedUrlIfRequired()
         performSegue(withIdentifier: "StartSegue", sender: self)
+    }
+    
+    func storeProvidedUrlIfRequired() {
+        var urls = [String]()
+        if let data = UserDefaults.standard.value(forKey:"serverUrlArray") as? Data {
+            urls = try! PropertyListDecoder().decode(Array<String>.self, from: data)
+        }
+        if (!urls.contains(serverField.text!)) {
+            urls.append(serverField.text!)
+        }
+        UserDefaults.standard.set(try? PropertyListEncoder().encode(urls), forKey:"serverUrlArray")
     }
     
     func onError() {

--- a/TraccarManager/StartViewController.swift
+++ b/TraccarManager/StartViewController.swift
@@ -15,10 +15,11 @@
 //
 
 import UIKit
+import iOSDropDown
 
 class StartViewController: UIViewController, UITextFieldDelegate {
     
-    @IBOutlet weak var serverField: UITextField!
+    @IBOutlet weak var serverField: DropDown!
     @IBOutlet weak var startButton: UIButton!
     
     @IBAction func onStart(_ sender: AnyObject) {
@@ -57,6 +58,9 @@ class StartViewController: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         serverField.delegate = self
+        serverField.optionArray = ["URL_1",
+                                   "URL_2",
+                                   "URL_3"]
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
This change allows the user to select the server URL from the dropdown on each application launch.
If the application works in background, it will not prompt user to select server URL after resume. To force app to open server URL selection screen - just stop application and launch it again.

Every time user puts a new server URL and presses the' Start' button, given URL is stored in UserPreferences and will load in dropdown list next time. 
Enjoy!

<img width="374" alt="Screen Shot 2020-03-23 at 19 25 14" src="https://user-images.githubusercontent.com/1929854/77346087-50d8b200-6d3e-11ea-86da-fd2f7b87f078.png">
<img width="372" alt="Screen Shot 2020-03-23 at 19 25 32" src="https://user-images.githubusercontent.com/1929854/77346093-52a27580-6d3e-11ea-974a-c4b5adbf4b68.png">